### PR TITLE
Bug fix decay rate

### DIFF
--- a/Traumschreiber_BLE_Code/ad_spi.c
+++ b/Traumschreiber_BLE_Code/ad_spi.c
@@ -407,9 +407,9 @@ void spi_encode_data(void)
         if (spi_running_average_enabled) {
             if (abs(m_value - spi_estimated_average[n_channel]) > std_5) {
                 if (m_value > spi_estimated_average[n_channel]) {
-                    spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_5 + spi_enc_estimate_factor_1*std_5;
+                    spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_9 + spi_enc_estimate_factor_1*std_5;
                 } else {
-                    spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_5 - spi_enc_estimate_factor_1*std_5;
+                    spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_9 - spi_enc_estimate_factor_1*std_5;
                 }
             } else {
                 spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_9 + spi_enc_estimate_factor_1*m_value;

--- a/Traumschreiber_BLE_Code/ad_spi.h
+++ b/Traumschreiber_BLE_Code/ad_spi.h
@@ -199,9 +199,9 @@ static uint32_t  spi_encode_shift[SPI_CHANNEL_NUMBER_TOTAL]     = {0x00}; //how 
 #define SPI_FACTOR_SAFE_ENCODING_DEFAULT   8
 static uint8_t spi_enc_factor_safe_encoding = SPI_FACTOR_SAFE_ENCODING_DEFAULT;
 static uint8_t spi_ble_send_devision = 0;
-static float32_t spi_enc_estimate_factor_9 = 0.999;
-static float32_t spi_enc_estimate_factor_1 = 0.001;
-static float32_t spi_enc_estimate_factor_5 = 1.004;
+static float32_t spi_enc_estimate_factor_9 = 0.995;
+static float32_t spi_enc_estimate_factor_1 = 0.005;
+static float32_t spi_enc_estimate_factor_5 = 1.005;
 static uint8_t spi_enc_warmup = 1;
 
 static uint8_t  spi_code_send_buf[CODE_CHAR_VALUE_LENGTH] = {0x44};    /**< TX buffer. */


### PR DESCRIPTION
changed 
static float32_t spi_enc_estimate_factor_9 = 0.995;  
static float32_t spi_enc_estimate_factor_1 = 0.005;  
static float32_t spi_enc_estimate_factor_5 = 1.005;
09:36 Uhr
4. We change line 410 with spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_5 + spi_enc_estimate_factor_1*std_5;  --->
spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_9 + spi_enc_estimate_factor_1*std_5;
5. We change line 412 with spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_5 - spi_enc_estimate_factor_1*std_5; --->
spi_estimated_average[n_channel] = spi_estimated_average[n_channel]*spi_enc_estimate_factor_9 - spi_enc_estimate_factor_1*std_5;